### PR TITLE
HCA-8 Fix writeFile issue on Android Q

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import fs from 'react-native-fs';
+import { Platform } from 'react-native';
 
 export const DocumentDir = fs.DocumentDirectoryPath;
 export const CacheDir = fs.CachesDirectoryPath;
@@ -51,6 +52,14 @@ const FSStorage = (
       await fs.mkdir(baseFolder, {
         NSURLIsExcludedFromBackupKey: excludeFromBackup,
       });
+      // SDK shipped with Android Q has a bug in writeFile method
+      // Until it is fixed we have to remove the file in question first
+      // before overriding it.
+      // https://jira.bgchtest.info/browse/HCA-8
+      // https://github.com/itinance/react-native-fs/issues/700
+      if (Platform.OS === 'android' && Platform.Version >= 29) {
+        await removeItem(key);
+      }
       await fs.writeFile(pathForKey(key), value, 'utf8');
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/redux-persist-fs-storage",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Peter Bevan<peter.bevan@hivehome.com>",
   "description": "Redux-Persist storage engine for React Native file system",
   "repository": "https://github.com/ConnectedHomes/redux-persist-fs-storage.git",
@@ -15,7 +15,7 @@
     "AsyncStorage"
   ],
   "dependencies": {
-    "react-native-fs": "2.12"
+    "react-native-fs": "2.14"
   },
   "peerDependencies": {
     "react-native": ">=0.57.0"


### PR DESCRIPTION
There seems to be a bug in the SDK shipped with Android Q related to `writeFile` method failing to override correctly the file in question (in our case resulting in corrupting persistence data). The fix is to remove the file first before trying to override it.

https://jira.bgchtest.info/browse/HCA-8